### PR TITLE
Update URLs to reference public repository

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ appropriately.
 
 Bug fixes and new features should include tests and documentation.
 
-Contributors guide: https://github.com/ittybittyapps/afterpay-example-server/tree/master/CONTRIBUTING.md
+Contributors guide: https://github.com/afterpay/sdk-example-server/tree/master/CONTRIBUTING.md
 -->
 
 ## Summary of Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If the above doesn't help, please [submit an issue][new-issue] via GitHub.
 
 - Click the [Fork][fork-repo] button in the upper right corner of the repository.
 - Clone your fork:
-    `git clone git@github.com:<YOUR_GITHUB_USER>/afterpay-example-server.git`
+    `git clone git@github.com:<YOUR_GITHUB_USER>/sdk-example-server.git`
 - See the [GitHub documentation][fork-docs] about managing your fork.
 
 #### Recommended
@@ -58,12 +58,12 @@ All contributions to this project are also under this license as per [GitHub's T
 [code-of-conduct]: CODE_OF_CONDUCT.md
 [code-owners]: .github/CODEOWNERS
 [commit-messages]: https://chris.beams.io/posts/git-commit/
-[fork-repo]: https://github.com/ittybittyapps/afterpay-example-server/fork
+[fork-repo]: https://github.com/afterpay/sdk-example-server/fork
 [fork-docs]: https://help.github.com/articles/working-with-forks/
 [github-terms-contribution]: https://help.github.com/en/github/site-policy/github-terms-of-service#6-contributions-under-repository-license
-[issues]: https://github.com/ittybittyapps/afterpay-example-server/issues
+[issues]: https://github.com/afterpay/sdk-example-server/issues
 [license]: LICENSE
-[new-issue]: https://github.com/ittybittyapps/afterpay-example-server/issues/new/choose
+[new-issue]: https://github.com/afterpay/sdk-example-server/issues/new/choose
 [pr-template]: .github/PULL_REQUEST_TEMPLATE.md
 [pr-docs]: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review
 [readme]: README.md

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Contributions are welcome! Please read our [contributing guidelines][contributin
 This project is licensed under the terms of the Apache 2.0 license. See the [LICENSE][license] file for more information.
 
 <!-- Links: -->
-[android-example]: https://github.com/ittybittyapps/afterpay-android/tree/master/example
-[build-status]: https://github.com/ittybittyapps/afterpay-example-server/actions?query=workflow%3A%22Build+and+Lint%22+event%3Apush+branch%3Amaster
-[build-status-badge]: https://github.com/ittybittyapps/afterpay-example-server/workflows/Build%20and%20Lint/badge.svg?branch=master&event=push
+[android-example]: https://github.com/afterpay/sdk-android/tree/master/example
+[build-status]: https://github.com/afterpay/sdk-example-server/actions?query=workflow%3A%22Build+and+Lint%22+event%3Apush+branch%3Amaster
+[build-status-badge]: https://github.com/afterpay/sdk-example-server/workflows/Build%20and%20Lint/badge.svg?branch=master&event=push
 [code-style-badge]: https://img.shields.io/badge/code_style-prettier-ff69b4.svg
 [contributing]: CONTRIBUTING.md
-[ios-example]: https://github.com/ittybittyapps/afterpay-ios/tree/master/Example
+[ios-example]: https://github.com/afterpay/sdk-ios/tree/master/Example
 [license]: LICENSE
 [localhost]: http://localhost:3000
 [node]: https://github.com/nodejs/node

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "afterpay-example-server",
+  "name": "afterpay-sdk-example-server",
   "version": "1.0.0",
   "description": "Server to power the iOS and Android SDK example applications",
   "main": "dist/server.js",
@@ -12,14 +12,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ittybittyapps/afterpay-example-server"
+    "url": "https://github.com/afterpay/sdk-example-server"
   },
   "author": "Afterpay",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/ittybittyapps/afterpay-example-server/issues"
+    "url": "https://github.com/afterpay/sdk-example-server/issues"
   },
-  "homepage": "https://github.com/ittybittyapps/afterpay-example-server#readme",
+  "homepage": "https://github.com/afterpay/sdk-example-server#readme",
   "devDependencies": {
     "@types/express": "^4.17.6",
     "@typescript-eslint/eslint-plugin": "^3.2.0",


### PR DESCRIPTION
## Summary of Changes

- Change GitHub URLs to reference [public Afterpay organisation](https://github.com/afterpay).