### PR TITLE
Inject Locale into config function

### DIFF
--- a/src/routes/configuration.ts
+++ b/src/routes/configuration.ts
@@ -1,11 +1,7 @@
 import { Handler } from 'express';
 import { request, RequestOptions } from 'https';
-import { Region, locale } from '../Region';
 
-const region = (process.env.AFTERPAY_REGION as Region) ?? Region.US;
-const regionLocale = locale(region);
-
-export function configuration(options: RequestOptions): Handler {
+export function configuration(locale: string, options: RequestOptions): Handler {
   return (req, res) => {
     const configOptions = {
       ...options,
@@ -18,7 +14,7 @@ export function configuration(options: RequestOptions): Handler {
         res.json({
           minimumAmount: responseObject.minimumAmount,
           maximumAmount: responseObject.maximumAmount,
-          locale: regionLocale
+          locale: locale
         });
       });
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import http from 'http';
 import https from 'https';
 import path from 'path';
-import { Region, configuration as regionConfiguration } from './Region';
+import { Region, locale, configuration as regionConfiguration } from './Region';
 import { configuration } from './routes/configuration';
 import { checkout } from './routes/checkout';
 
@@ -34,7 +34,7 @@ const certificates = {
 
 const app = express()
   .use(bodyParser.json())
-  .get('/configuration', configuration(defaultOptions))
+  .get('/configuration', configuration(locale(region), defaultOptions))
   .post('/checkouts', checkout(regionConfig, defaultOptions));
 
 const httpPort = 3000;


### PR DESCRIPTION
Previously, it was reading it from the env vars. It is preferable to have it injected.

This is a follow-up PR to https://github.com/afterpay/sdk-example-server/pull/20 which I merged a little too eagerly 