### PR TITLE
Add language and country to locale to support forming Android locales

### DIFF
--- a/src/Region.ts
+++ b/src/Region.ts
@@ -26,17 +26,23 @@ export function configuration(region: Region): RegionConfiguration {
   }
 }
 
-export function locale(region: Region): string {
+export type Locale = {
+  identifier: string;
+  language: string;
+  country: string;
+};
+
+export function locale(region: Region): Locale {
   switch (region) {
     case Region.AU:
-      return 'en_AU';
+      return { identifier: 'en_AU', language: 'en', country: 'AU' };
     case Region.CA:
-      return 'en_CA';
+      return { identifier: 'en_CA', language: 'en', country: 'CA' };
     case Region.NZ:
-      return 'en_NZ';
+      return { identifier: 'en_NZ', language: 'en', country: 'NZ' };
     case Region.US:
-      return 'en_US';
+      return { identifier: 'en_US', language: 'en', country: 'US' };
     case Region.UK:
-      return 'en_UK';
+      return { identifier: 'en_UK', language: 'en', country: 'UK' };
   }
 }

--- a/src/routes/configuration.ts
+++ b/src/routes/configuration.ts
@@ -1,7 +1,8 @@
 import { Handler } from 'express';
 import { request, RequestOptions } from 'https';
+import { Locale } from '../Region';
 
-export function configuration(locale: string, options: RequestOptions): Handler {
+export function configuration(locale: Locale, options: RequestOptions): Handler {
   return (req, res) => {
     const configOptions = {
       ...options,
@@ -12,8 +13,7 @@ export function configuration(locale: string, options: RequestOptions): Handler 
       configRes.on('data', (d) => {
         const responseObject = JSON.parse(d);
         res.json({
-          minimumAmount: responseObject.minimumAmount,
-          maximumAmount: responseObject.maximumAmount,
+          ...responseObject,
           locale: locale
         });
       });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-example-server/tree/master/CONTRIBUTING.md
-->

## Summary of Changes

Adds more locale information to properly form locales on both iOS and Android

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Adds the `Locale` type
- Moves previous incarnation of locale string under the `identifier` sub property
- Adds `language` and `country`

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

As the iOS example app is currently consuming locale it will need to be updated
