### PR TITLE
Add bootstrap HTML for the widget

### DIFF
--- a/widget-bootstrap.html
+++ b/widget-bootstrap.html
@@ -1,0 +1,93 @@
+<html>
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	</head>
+	<body>
+		<div id="afterpay-widget-container" style="margin: 16px 0px"></div>
+
+		<script>
+			const app = window.webkit.messageHandlers.iOS;
+
+			function createAfterpayWidget(token, amount, locale, style) {
+				
+				new MutationObserver(() => {
+						const height = document.getElementById("afterpay-widget-container").offsetHeight + 36; // plus extra px for margins
+						app.postMessage(JSON.stringify({ "type": "resize", "size": height }));
+					})
+					.observe(
+						document.getElementById('afterpay-widget-container'),
+						{ attributes: true, childList: true, subtree: true }
+					);
+				
+				window.afterpayWidget = new AfterPay.Widgets.PaymentSchedule({
+					token: token,
+					target: "#afterpay-widget-container",
+					locale: locale.replaceAll("_", "-"),
+					amount: amount, 
+					onReady: function (event) {
+						sendToApp(event);
+					},
+					onChange: function (event) {
+						sendToApp(event);
+					},
+					onError: function (event) {
+						sendToApp(event);
+					},
+					style: {
+						border: false,
+						logo: style.logo,
+						heading: style.heading,
+					}
+				});
+			}
+
+			function sendToApp(event) {
+				const data = event.data;
+				let completeData = {
+					...data,
+					"type": event.type
+				};
+				
+				if (typeof data.amountDueToday !== 'undefined') {
+					completeData.amountDueToday = {
+						"amount": data.amountDueToday.amount,
+						"currency": data.amountDueToday.currency
+					}
+				}
+				
+				app.postMessage(JSON.stringify(completeData));
+			}
+
+			function updateAmount(amount) {
+				window.afterpayWidget.update({
+					amount: amount 
+				});
+			}
+			
+			/// Returns the complete status update of the widget.
+			/// 
+			/// Rather than the SDK having to ask about each property individually in turn, this collects it into one.
+			function getWidgetStatus() {
+				const widget = window.afterpayWidget;
+				
+				let data = {
+					"isValid": widget.isValid,
+					"paymentScheduleChecksum": widget.paymentScheduleChecksum,
+					"error": widget.error
+				}
+				
+				if (typeof widget.amountDueToday !== 'undefined') {
+					data.amountDueToday = {
+						"amount": widget.amountDueToday.amount,
+						"currency": widget.amountDueToday.currency
+					}
+				}
+				
+				return JSON.stringify(data);
+			}
+
+			</script>
+
+		<script src="https://portal.sandbox.afterpay.com/afterpay.js?merchant_key=demo"></script>
+	</body>
+</html>

--- a/widget-bootstrap.html
+++ b/widget-bootstrap.html
@@ -86,8 +86,6 @@
 				return JSON.stringify(data);
 			}
 
-			</script>
-
-		<script src="https://portal.sandbox.afterpay.com/afterpay.js?merchant_key=demo"></script>
+		</script>
 	</body>
 </html>


### PR DESCRIPTION
This is the bootstrap for the checkout widget. It only supports iOS at the moment, and has a few minor issues.

### KNOWN ISSUES:

- Styling is hard to do
- Hard-coded merchant key is `demo`

### Hosting

On macOS, navigate to this repo in Terminal and run:

```sh
python -m SimpleHTTPServer
```

This will start the bootstrap on port 8000.