### PR TITLE
Make postMessage work on Android

### DIFF
--- a/widget-bootstrap.html
+++ b/widget-bootstrap.html
@@ -6,24 +6,39 @@
 		<div id="afterpay-widget-container" style="margin: 16px 0px"></div>
 
 		<script>
-			const app = window.webkit.messageHandlers.iOS;
+
+			function postToApp(message) {
+				let app;
+
+				try {
+					app = window.webkit.messageHandlers.iOS;
+				} catch { }
+
+				if (typeof app === 'undefined' && typeof Android !== 'undefined') {
+					app = Android;
+				}
+
+				if (typeof app !== 'undefined') {
+					app.postMessage(message);
+				}
+			}
 
 			function createAfterpayWidget(token, amount, locale, style) {
-				
+
 				new MutationObserver(() => {
 						const height = document.getElementById("afterpay-widget-container").offsetHeight + 36; // plus extra px for margins
-						app.postMessage(JSON.stringify({ "type": "resize", "size": height }));
+						postToApp(JSON.stringify({ "type": "resize", "size": height }));
 					})
 					.observe(
 						document.getElementById('afterpay-widget-container'),
 						{ attributes: true, childList: true, subtree: true }
 					);
-				
+
 				window.afterpayWidget = new AfterPay.Widgets.PaymentSchedule({
 					token: token,
 					target: "#afterpay-widget-container",
 					locale: locale.replaceAll("_", "-"),
-					amount: amount, 
+					amount: amount,
 					onReady: function (event) {
 						sendToApp(event);
 					},
@@ -47,42 +62,42 @@
 					...data,
 					"type": event.type
 				};
-				
+
 				if (typeof data.amountDueToday !== 'undefined') {
 					completeData.amountDueToday = {
 						"amount": data.amountDueToday.amount,
 						"currency": data.amountDueToday.currency
 					}
 				}
-				
-				app.postMessage(JSON.stringify(completeData));
+
+				postToApp(JSON.stringify(completeData));
 			}
 
 			function updateAmount(amount) {
 				window.afterpayWidget.update({
-					amount: amount 
+					amount: amount
 				});
 			}
-			
+
 			/// Returns the complete status update of the widget.
-			/// 
+			///
 			/// Rather than the SDK having to ask about each property individually in turn, this collects it into one.
 			function getWidgetStatus() {
 				const widget = window.afterpayWidget;
-				
+
 				let data = {
 					"isValid": widget.isValid,
 					"paymentScheduleChecksum": widget.paymentScheduleChecksum,
 					"error": widget.error
 				}
-				
+
 				if (typeof widget.amountDueToday !== 'undefined') {
 					data.amountDueToday = {
 						"amount": widget.amountDueToday.amount,
 						"currency": widget.amountDueToday.currency
 					}
 				}
-				
+
 				return JSON.stringify(data);
 			}
 

--- a/widget-bootstrap.html
+++ b/widget-bootstrap.html
@@ -23,6 +23,14 @@
 				}
 			}
 
+			/// Load the widget, and place it in the #afterpay-widget-container div.
+			///
+			/// One of `token` or `amount` must be provided. Use the `token` for tokened-mode, use `amount` for tokenless.
+			///
+			/// - token: checkout token. Use `null` for tokenless mode.
+			/// - amount: the total payment as a money object. eg: { "amount": "20.00", "currency": "USD" }. Only provide for tokenless mode, otherwise, use `null`.
+			/// - locale: locale to use in the widget.
+			/// - style: style options for the widget, eg: { "logo": true, "heading": false }.
 			function createAfterpayWidget(token, amount, locale, style) {
 
 				new MutationObserver(() => {


### PR DESCRIPTION
Previously, our postMessage only worked on iOS.

To get it working on Android too, we need to get the message handler object from somewhere else. iOS has it on `window.webkit.messageHandler.iOS`, whereas Android has it straight on `Android`. This way, both platforms can send messages to their message handlers using the `postToApp` function, which encapsulates this.

This technique was also used in the checkout bootstrap.
