### PR TITLE
Use `replace` rather than `replaceAll`

### DIFF
--- a/widget-bootstrap.html
+++ b/widget-bootstrap.html
@@ -45,7 +45,7 @@
 				window.afterpayWidget = new AfterPay.Widgets.PaymentSchedule({
 					token: token,
 					target: "#afterpay-widget-container",
-					locale: locale.replaceAll("_", "-"),
+					locale: locale.replace("_", "-"),
 					amount: amount,
 					onReady: function (event) {
 						sendToApp(event);


### PR DESCRIPTION
Apparently, `replaceAll` is a newer function which is not available in all mobile browsers. `replace` does the job we want well enough, though, and is more compatible.
