### PR TITLE
Only send resize event when height is positive

### DIFF
--- a/widget-bootstrap.html
+++ b/widget-bootstrap.html
@@ -33,8 +33,10 @@
       function createAfterpayWidget(token, amount, locale, style) {
 
         new MutationObserver(() => {
-            const height = document.getElementById("afterpay-widget-container").offsetHeight + 36; // plus extra px for margins
-            postToApp(JSON.stringify({ "type": "resize", "size": height }));
+            const height = document.getElementById("afterpay-widget-container").offsetHeight;
+            if (height > 0) {
+              postToApp(JSON.stringify({ "type": "resize", "size": height + 36 })); // plus extra px for margins
+            }
           })
           .observe(
             document.getElementById('afterpay-widget-container'),


### PR DESCRIPTION
Previously, this sent a lot of events while the offset height was 0. It would be better if only sent them when it is positive.
