### PR TITLE
Forward checkout errors to client

### DIFF
--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -46,10 +46,19 @@ export function checkout(configuration: RegionConfiguration, options: RequestOpt
     const checkoutRequest = request(checkoutOptions, (configRes) => {
       configRes.on('data', (d) => {
         const responseObject = JSON.parse(d);
-        res.json({
-          token: responseObject.token,
-          url: responseObject.redirectCheckoutUrl
-        });
+
+        if (responseObject.errorCode !== undefined) {
+          console.log(responseObject);
+          res.json({
+            errorCode: responseObject.errorCode,
+            message: responseObject.message
+          });
+        } else {
+          res.json({
+            token: responseObject.token,
+            url: responseObject.redirectCheckoutUrl
+          });
+        }
       });
     });
 


### PR DESCRIPTION
Sometimes, errors in the checkout occur. When they do, the response was from our example API was a simple `{}` which was not very informative.

Now we send back the error code and message from the checkout API along to the client. What the client wants to do it with it is up to them.
