### PR TITLE
Feature: migrate to global api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "afterpay-example-server",
+  "name": "afterpay-sdk-example-server",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/Region.ts
+++ b/src/Region.ts
@@ -7,22 +7,21 @@ export enum Region {
 }
 
 export type RegionConfiguration = {
-  hostname: string;
   currency: string;
 };
 
 export function configuration(region: Region): RegionConfiguration {
   switch (region) {
     case Region.AU:
-      return { hostname: 'api-sandbox.afterpay.com', currency: 'AUD' };
+      return { currency: 'AUD' };
     case Region.CA:
-      return { hostname: 'api.us-sandbox.afterpay.com', currency: 'CAD' };
+      return { currency: 'CAD' };
     case Region.NZ:
-      return { hostname: 'api-sandbox.afterpay.com', currency: 'NZD' };
+      return { currency: 'NZD' };
     case Region.US:
-      return { hostname: 'api.us-sandbox.afterpay.com', currency: 'USD' };
+      return { currency: 'USD' };
     case Region.UK:
-      return { hostname: 'api.eu-sandbox.afterpay.com', currency: 'GBP' };
+      return { currency: 'GBP' };
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,7 @@ const regionConfig = regionConfiguration(region);
 
 const defaultOptions: https.RequestOptions = {
   auth: `${merchantId}:${secretKey}`,
-  hostname: regionConfig.hostname
+  hostname: 'global-api-sandbox.afterpay.com'
 };
 
 const certificates = {


### PR DESCRIPTION
## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Remove `hostname` property from `RegionConfiguration` type
- Remove all `hostname` props from configuration switch
- hardcode the default config to be the global api
