### PR TITLE
Feature: add support for eu and fr-ca regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ A server to power the [iOS][ios-example] and [Android][android-example] SDK exam
 
 ### Region
 
-The region is specified with the `AFTERPAY_REGION` environment variable in the format of an ISO 3166 two-letter country code.
+The region is specified with the `AFTERPAY_REGION` environment variable in the format of an IETF language four-letter hyphen separated language code and country code. (ie `en-NZ`)
 
-Supported regions are: AU, NZ, US and CA.
+Supported regions are: `en-AU`, `en-CA`, `en-CA`, `es-ES`, `fr-FR`, `it-IT`, `en-NZ` and `en-US`.
 
-> **NOTE**: The example server will fallback to the US region if the environment variable is not set.
+> **NOTE**: The example server will fallback to the `en-US` region if the environment variable is not set.
 
 ### Authentication
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "afterpay-sdk-example-server",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "afterpay-sdk-example-server",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "afterpay-sdk-example-server",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Server to power the iOS and Android SDK example applications",
   "main": "dist/server.js",
   "scripts": {

--- a/src/Region.ts
+++ b/src/Region.ts
@@ -1,9 +1,13 @@
 export enum Region {
-  AU = 'AU',
-  CA = 'CA',
-  NZ = 'NZ',
-  US = 'US',
-  UK = 'UK'
+  EN_AU = 'EN_AU',
+  EN_CA = 'EN_CA',
+  FR_CA = 'FR_CA',
+  EN_NZ = 'EN_NZ',
+  EN_US = 'EN_US',
+  EN_UK = 'EN_UK',
+  FR_FR = 'FR_FR',
+  IT_IT = 'IT_IT',
+  ES_ES = 'ES_ES',
 }
 
 export type RegionConfiguration = {
@@ -12,16 +16,21 @@ export type RegionConfiguration = {
 
 export function configuration(region: Region): RegionConfiguration {
   switch (region) {
-    case Region.AU:
+    case Region.EN_AU:
       return { currency: 'AUD' };
-    case Region.CA:
+    case Region.EN_CA:
+    case Region.FR_CA:
       return { currency: 'CAD' };
-    case Region.NZ:
+    case Region.EN_NZ:
       return { currency: 'NZD' };
-    case Region.US:
+    case Region.EN_US:
       return { currency: 'USD' };
-    case Region.UK:
+    case Region.EN_UK:
       return { currency: 'GBP' };
+    case Region.FR_FR:
+    case Region.IT_IT:
+    case Region.ES_ES:
+      return { currency: 'EUR' };
   }
 }
 
@@ -33,15 +42,23 @@ export type Locale = {
 
 export function locale(region: Region): Locale {
   switch (region) {
-    case Region.AU:
+    case Region.EN_AU:
       return { identifier: 'en_AU', language: 'en', country: 'AU' };
-    case Region.CA:
+    case Region.EN_CA:
       return { identifier: 'en_CA', language: 'en', country: 'CA' };
-    case Region.NZ:
+    case Region.FR_CA:
+      return { identifier: 'fr_CA', language: 'fr', country: 'CA' };
+    case Region.EN_NZ:
       return { identifier: 'en_NZ', language: 'en', country: 'NZ' };
-    case Region.US:
+    case Region.EN_US:
       return { identifier: 'en_US', language: 'en', country: 'US' };
-    case Region.UK:
+    case Region.EN_UK:
       return { identifier: 'en_GB', language: 'en', country: 'GB' };
+    case Region.FR_FR:
+      return { identifier: 'fr_FR', language: 'fr', country: 'FR' };
+    case Region.IT_IT:
+      return { identifier: 'it_IT', language: 'it', country: 'IT' };
+    case Region.ES_ES:
+      return { identifier: 'es_ES', language: 'es', country: 'ES' };
   }
 }

--- a/src/Region.ts
+++ b/src/Region.ts
@@ -1,13 +1,13 @@
 export enum Region {
-  EN_AU = 'EN_AU',
-  EN_CA = 'EN_CA',
-  FR_CA = 'FR_CA',
-  EN_NZ = 'EN_NZ',
-  EN_US = 'EN_US',
-  EN_UK = 'EN_UK',
-  FR_FR = 'FR_FR',
-  IT_IT = 'IT_IT',
-  ES_ES = 'ES_ES',
+  EN_AU = 'en-AU',
+  EN_CA = 'en-CA',
+  FR_CA = 'fr-CA',
+  EN_NZ = 'en-NZ',
+  EN_US = 'en-US',
+  EN_UK = 'en-UK',
+  FR_FR = 'fr-FR',
+  IT_IT = 'it-IT',
+  ES_ES = 'es-ES',
 }
 
 export type RegionConfiguration = {

--- a/src/Region.ts
+++ b/src/Region.ts
@@ -7,7 +7,7 @@ export enum Region {
   EN_UK = 'en-UK',
   FR_FR = 'fr-FR',
   IT_IT = 'it-IT',
-  ES_ES = 'es-ES',
+  ES_ES = 'es-ES'
 }
 
 export type RegionConfiguration = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,7 +22,7 @@ if (merchantId === undefined || secretKey === undefined) {
   process.exit(1);
 }
 
-const region = (process.env.AFTERPAY_REGION as Region) ?? Region.US;
+const region = (process.env.AFTERPAY_REGION as Region) ?? Region.EN_US;
 const regionConfig = regionConfiguration(region);
 
 const defaultOptions: https.RequestOptions = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-example-server/tree/master/CONTRIBUTING.md
-->

## Summary of Changes

- Add fr-FR, es-ES, it-IT and fr-CA regions and relevant configurations

## Items of Note

When setting environment variables the string is no longer a 2 letter country code but rather an IETF language tag including the country. For example instead of using `CA` for Canada, either either use `en-CA` or `fr-CA`.

## Submission Checklist

- [x] Documentation is changed or added.
