### PR TITLE
Add cash app option

### DIFF
--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -4,7 +4,7 @@ import { request, RequestOptions } from 'https';
 
 export function checkout(configuration: RegionConfiguration, options: RequestOptions): Handler {
   return (req, res) => {
-    const { email, amount, mode, isCashApp } = req.body;
+    const { email, amount, mode, isCashAppPay } = req.body;
 
     if (email === undefined) {
       throw new Error('Expected email in request body');
@@ -28,7 +28,7 @@ export function checkout(configuration: RegionConfiguration, options: RequestOpt
         popupOriginUrl: 'https://static.afterpay.com'
       },
       mode: mode,
-      isCashAppPay: isCashApp || false
+      isCashAppPay: isCashAppPay || false
     };
 
     const bodyData = JSON.stringify(body);

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -4,7 +4,7 @@ import { request, RequestOptions } from 'https';
 
 export function checkout(configuration: RegionConfiguration, options: RequestOptions): Handler {
   return (req, res) => {
-    const { email, amount, mode } = req.body;
+    const { email, amount, mode, isCashApp } = req.body;
 
     if (email === undefined) {
       throw new Error('Expected email in request body');
@@ -27,7 +27,8 @@ export function checkout(configuration: RegionConfiguration, options: RequestOpt
         redirectCancelUrl: 'https://example.com/some/path/cancel',
         popupOriginUrl: 'https://static.afterpay.com'
       },
-      mode: mode
+      mode: mode,
+      isCashAppPay: isCashApp || false,
     };
 
     const bodyData = JSON.stringify(body);

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -28,7 +28,7 @@ export function checkout(configuration: RegionConfiguration, options: RequestOpt
         popupOriginUrl: 'https://static.afterpay.com'
       },
       mode: mode,
-      isCashAppPay: isCashApp || false,
+      isCashAppPay: isCashApp || false
     };
 
     const bodyData = JSON.stringify(body);


### PR DESCRIPTION
## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- When creating the checkout, add an `isCashAppPay` option which can be passed in via the request body as `isCashApp`
